### PR TITLE
Support 2nd, 3rd etc. I2C hardware interface. Support ESP32 sda and scl signal mapping. A little bit of refactoring.

### DIFF
--- a/examples/Hello_World_Wire1/Hello_World_Wire1.ino
+++ b/examples/Hello_World_Wire1/Hello_World_Wire1.ino
@@ -19,7 +19,9 @@
 
 #include <LCD_I2C.h>
 
-LCD_I2C lcd(0x27, 16, 2); // Default address of most PCF8574 modules, change according
+// Use the second I2C interface 'Wire1'. (E.g. Arduino Due or ESP32 support two I2C interfaces.)
+extern TwoWire Wire1;
+LCD_I2C lcd(Wire1, 0x27, 16, 2); // Default address of most PCF8574 modules, change according
 
 void setup()
 {
@@ -29,7 +31,7 @@ void setup()
     //
     //   lcd.begin(4,5);
     //
-    // which maps 'Wire' sda to pin 4 and scl to pin 5 in this example.
+    // which maps 'Wire1' sda to pin 4 and scl to pin 5 in this example.
 
     lcd.backlight();
 }

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -277,14 +277,12 @@ void LCD_I2C::I2C_Write(uint8_t output)
 
 void LCD_I2C::LCD_Write(uint8_t output, bool initialization)
 {
-    _output.data = output;
-
     _output.E = true;
-    I2C_Write(_output.getHighData());
+    I2C_Write(_output.getHighData(output));
     delayMicroseconds(1); // High part of enable should be >450 nS
 
     _output.E = false;
-    I2C_Write(_output.getHighData());
+    I2C_Write(_output.getHighData(output));
 
     // During initialization we only send half a byte
     if (!initialization)
@@ -292,11 +290,11 @@ void LCD_I2C::LCD_Write(uint8_t output, bool initialization)
         delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
 
         _output.E = true;
-        I2C_Write(_output.getLowData());
+        I2C_Write(_output.getLowData(output));
         delayMicroseconds(1); // High part of enable should be >450 nS
 
         _output.E = false;
-        I2C_Write(_output.getLowData());
+        I2C_Write(_output.getLowData(output));
     }
     //delayMicroseconds(37); // Some commands have different timing requirement,
                              // so every command should handle its own delay after execution

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -71,7 +71,7 @@ void LCD_I2C::clear()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_Write(0b00000001);
+    LCD_WriteByte(0b00000001);
     delayMicroseconds(1600);
 }
 
@@ -80,7 +80,7 @@ void LCD_I2C::home()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_Write(0b00000010);
+    LCD_WriteByte(0b00000010);
     delayMicroseconds(1600);
 }
 
@@ -92,7 +92,7 @@ void LCD_I2C::leftToRight()
 
     _entryState |= 1 << 1;
 
-    LCD_Write(0b00000100 | _entryState);
+    LCD_WriteByte(0b00000100 | _entryState);
     delayMicroseconds(37);
 }
 
@@ -104,7 +104,7 @@ void LCD_I2C::rightToLeft()
 
     _entryState &= ~(1 << 1);
 
-    LCD_Write(0b00000100 | _entryState);
+    LCD_WriteByte(0b00000100 | _entryState);
     delayMicroseconds(37);
 }
 
@@ -116,7 +116,7 @@ void LCD_I2C::autoscroll()
 
     _entryState |= 1;
 
-    LCD_Write(0b00000100 | _entryState);
+    LCD_WriteByte(0b00000100 | _entryState);
     delayMicroseconds(37);
 }
 
@@ -128,7 +128,7 @@ void LCD_I2C::noAutoscroll()
 
     _entryState &= ~1;
 
-    LCD_Write(0b00000100 | _entryState);
+    LCD_WriteByte(0b00000100 | _entryState);
     delayMicroseconds(37);
 }
 
@@ -140,7 +140,7 @@ void LCD_I2C::display()
 
     _displayState |= 1 << 2;
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -152,7 +152,7 @@ void LCD_I2C::noDisplay()
 
     _displayState &= ~(1 << 2);
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -164,7 +164,7 @@ void LCD_I2C::cursor()
 
     _displayState |= 1 << 1;
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -176,7 +176,7 @@ void LCD_I2C::noCursor()
 
     _displayState &= ~(1 << 1);
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -188,7 +188,7 @@ void LCD_I2C::blink()
 
     _displayState |= 1;
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -200,7 +200,7 @@ void LCD_I2C::noBlink()
 
     _displayState &= ~1;
 
-    LCD_Write(0b00001000 | _displayState);
+    LCD_WriteByte(0b00001000 | _displayState);
     delayMicroseconds(37);
 }
 
@@ -210,7 +210,7 @@ void LCD_I2C::scrollDisplayLeft()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_Write(0b00011000);
+    LCD_WriteByte(0b00011000);
     delayMicroseconds(37);
 }
 
@@ -220,7 +220,7 @@ void LCD_I2C::scrollDisplayRight()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_Write(0b00011100);
+    LCD_WriteByte(0b00011100);
     delayMicroseconds(37);
 }
 
@@ -232,7 +232,7 @@ void LCD_I2C::createChar(uint8_t location, uint8_t charmap[])
 
     location %= 8;
 
-    LCD_Write(0b01000000 | (location << 3));
+    LCD_WriteByte(0b01000000 | (location << 3));
     delayMicroseconds(37);
 
     for (int i = 0; i < 8; i++)
@@ -253,7 +253,7 @@ void LCD_I2C::setCursor(uint8_t col, uint8_t row)
 
     const uint8_t newAddress = row_offsets[row] + col;
 
-    LCD_Write(0b10000000 | newAddress);
+    LCD_WriteByte(0b10000000 | newAddress);
     delayMicroseconds(37);
 }
 
@@ -262,7 +262,7 @@ size_t LCD_I2C::write(uint8_t character)
     _output.rs = 1;
     _output.rw = 0;
 
-    LCD_Write(character);
+    LCD_WriteByte(character);
     delayMicroseconds(41);
 
     return 1;
@@ -274,15 +274,15 @@ void LCD_I2C::InitializeLCD()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_Write(0b00110000, true);
+    LCD_WriteNibble(0b00110000);
     delayMicroseconds(4200);
-    LCD_Write(0b00110000, true);
+    LCD_WriteNibble(0b00110000);
     delayMicroseconds(150);
-    LCD_Write(0b00110000, true);
+    LCD_WriteNibble(0b00110000);
     delayMicroseconds(37);
-    LCD_Write(0b00100000, true); // Function Set - 4 bits mode
+    LCD_WriteNibble(0b00100000); // Function Set - 4 bits mode
     delayMicroseconds(37);
-    LCD_Write(0b00101000); // Function Set - 4 bits(Still), 2 lines, 5x8 font
+    LCD_WriteByte(0b00101000); // Function Set - 4 bits(Still), 2 lines, 5x8 font
     delayMicroseconds(37);
 
     display();
@@ -297,27 +297,22 @@ void LCD_I2C::I2C_Write(uint8_t output)
     _wire.endTransmission();
 }
 
-void LCD_I2C::LCD_Write(uint8_t output, bool initialization)
+void LCD_I2C::LCD_WriteNibble(uint8_t output)
 {
-    _output.E = true;
-    I2C_Write(_output.getHighData(output));
+    I2C_Write(_output.getHighData(output, true));
     delayMicroseconds(1); // High part of enable should be >450 nS
+    I2C_Write(_output.getHighData(output, false));
+}
 
-    _output.E = false;
-    I2C_Write(_output.getHighData(output));
+void LCD_I2C::LCD_WriteByte(uint8_t output)
+{
+	LCD_WriteNibble(output);
+	delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
 
-    // During initialization we only send half a byte
-    if (!initialization)
-    {
-        delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
+	I2C_Write(_output.getLowData(output, true));
+	delayMicroseconds(1); // High part of enable should be >450 nS
+	I2C_Write(_output.getLowData(output, false));
 
-        _output.E = true;
-        I2C_Write(_output.getLowData(output));
-        delayMicroseconds(1); // High part of enable should be >450 nS
-
-        _output.E = false;
-        I2C_Write(_output.getLowData(output));
-    }
     //delayMicroseconds(37); // Some commands have different timing requirement,
                              // so every command should handle its own delay after execution
 }

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -280,11 +280,11 @@ void LCD_I2C::LCD_Write(uint8_t output, bool initialization)
     _output.data = output;
 
     _output.E = true;
-    I2C_Write(_output.GetHighData());
+    I2C_Write(_output.getHighData());
     delayMicroseconds(1); // High part of enable should be >450 nS
 
     _output.E = false;
-    I2C_Write(_output.GetHighData());
+    I2C_Write(_output.getHighData());
 
     // During initialization we only send half a byte
     if (!initialization)
@@ -292,11 +292,11 @@ void LCD_I2C::LCD_Write(uint8_t output, bool initialization)
         delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
 
         _output.E = true;
-        I2C_Write(_output.GetLowData());
+        I2C_Write(_output.getLowData());
         delayMicroseconds(1); // High part of enable should be >450 nS
 
         _output.E = false;
-        I2C_Write(_output.GetLowData());
+        I2C_Write(_output.getLowData());
     }
     //delayMicroseconds(37); // Some commands have different timing requirement,
                              // so every command should handle its own delay after execution

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -21,9 +21,19 @@
 #include "LCD_I2C.h"
 #include "Wire.h"
 
+void LCD_I2C::begin(int sdaPin, int sclPin, bool beginWire)
+{
+#if defined (ESP32)
+	// ESP32 requires setting sda and scl pins.
+	Wire.setPins(sdaPin, sclPin);
+#endif
+	begin(beginWire);
+}
+
 void LCD_I2C::begin(bool beginWire)
 {
-    if (beginWire)
+
+	if (beginWire)
         Wire.begin();
 
     I2C_Write(0b00000000); // Clear i2c adapter

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -21,11 +21,23 @@
 #include "LCD_I2C.h"
 #include "Wire.h"
 
+LCD_I2C::LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns, uint8_t rows)
+    : _wire(wire) // Use the TwoWire object passed as parameter.
+	, _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+{
+}
+
+LCD_I2C::LCD_I2C(uint8_t address, uint8_t columns, uint8_t rows)
+	: _wire(Wire) // Use the default object 'Wire'.
+	, _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+{
+}
+
 void LCD_I2C::begin(int sdaPin, int sclPin, bool beginWire)
 {
 #if defined (ESP32)
 	// ESP32 requires setting sda and scl pins.
-	Wire.setPins(sdaPin, sclPin);
+	_wire.setPins(sdaPin, sclPin);
 #endif
 	begin(beginWire);
 }
@@ -34,7 +46,7 @@ void LCD_I2C::begin(bool beginWire)
 {
 
 	if (beginWire)
-        Wire.begin();
+        _wire.begin();
 
     I2C_Write(0b00000000); // Clear i2c adapter
     delay(50); //Wait more than 40ms after powerOn.
@@ -280,9 +292,9 @@ void LCD_I2C::InitializeLCD()
 
 void LCD_I2C::I2C_Write(uint8_t output)
 {
-    Wire.beginTransmission(_address);
-    Wire.write(output);
-    Wire.endTransmission();
+    _wire.beginTransmission(_address);
+    _wire.write(output);
+    _wire.endTransmission();
 }
 
 void LCD_I2C::LCD_Write(uint8_t output, bool initialization)

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -229,7 +229,7 @@ void LCD_I2C::setCursor(uint8_t col, uint8_t row)
     if(col > _columnMax) { col = _columnMax; } // sanity limits
     if(row > _rowMax) { row = _rowMax; } // sanity limits
 
-    uint8_t newAddress = row_offsets[row] + col;
+    const uint8_t newAddress = row_offsets[row] + col;
 
     LCD_Write(0b10000000 | newAddress);
     delayMicroseconds(37);

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -274,13 +274,13 @@ void LCD_I2C::InitializeLCD()
     _output.rs = 0;
     _output.rw = 0;
 
-    LCD_WriteNibble(0b00110000);
+    LCD_WriteHighNibble(0b00110000);
     delayMicroseconds(4200);
-    LCD_WriteNibble(0b00110000);
+    LCD_WriteHighNibble(0b00110000);
     delayMicroseconds(150);
-    LCD_WriteNibble(0b00110000);
+    LCD_WriteHighNibble(0b00110000);
     delayMicroseconds(37);
-    LCD_WriteNibble(0b00100000); // Function Set - 4 bits mode
+    LCD_WriteHighNibble(0b00100000); // Function Set - 4 bits mode
     delayMicroseconds(37);
     LCD_WriteByte(0b00101000); // Function Set - 4 bits(Still), 2 lines, 5x8 font
     delayMicroseconds(37);
@@ -297,7 +297,7 @@ void LCD_I2C::I2C_Write(uint8_t output)
     _wire.endTransmission();
 }
 
-void LCD_I2C::LCD_WriteNibble(uint8_t output)
+void LCD_I2C::LCD_WriteHighNibble(uint8_t output)
 {
     I2C_Write(_output.getHighData(output, true));
     delayMicroseconds(1); // High part of enable should be >450 nS
@@ -306,7 +306,7 @@ void LCD_I2C::LCD_WriteNibble(uint8_t output)
 
 void LCD_I2C::LCD_WriteByte(uint8_t output)
 {
-	LCD_WriteNibble(output);
+	LCD_WriteHighNibble(output);
 	delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
 
 	I2C_Write(_output.getLowData(output, true));

--- a/src/LCD_I2C.cpp
+++ b/src/LCD_I2C.cpp
@@ -23,29 +23,29 @@
 
 LCD_I2C::LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns, uint8_t rows)
     : _wire(wire) // Use the TwoWire object passed as parameter.
-	, _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+    , _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
 {
 }
 
 LCD_I2C::LCD_I2C(uint8_t address, uint8_t columns, uint8_t rows)
-	: _wire(Wire) // Use the default object 'Wire'.
-	, _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
+    : _wire(Wire) // Use the default object 'Wire'.
+    , _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00)
 {
 }
 
 void LCD_I2C::begin(int sdaPin, int sclPin, bool beginWire)
 {
 #if defined (ESP32)
-	// ESP32 requires setting sda and scl pins.
-	_wire.setPins(sdaPin, sclPin);
+    // ESP32 requires setting sda and scl pins.
+    _wire.setPins(sdaPin, sclPin);
 #endif
-	begin(beginWire);
+    begin(beginWire);
 }
 
 void LCD_I2C::begin(bool beginWire)
 {
 
-	if (beginWire)
+    if (beginWire)
         _wire.begin();
 
     I2C_Write(0b00000000); // Clear i2c adapter
@@ -306,12 +306,12 @@ void LCD_I2C::LCD_WriteHighNibble(uint8_t output)
 
 void LCD_I2C::LCD_WriteByte(uint8_t output)
 {
-	LCD_WriteHighNibble(output);
-	delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
+    LCD_WriteHighNibble(output);
+    delayMicroseconds(37); // I think we need a delay between half byte writes, but no sure how long it needs to be.
 
-	I2C_Write(_output.getLowData(output, true));
-	delayMicroseconds(1); // High part of enable should be >450 nS
-	I2C_Write(_output.getLowData(output, false));
+    I2C_Write(_output.getLowData(output, true));
+    delayMicroseconds(1); // High part of enable should be >450 nS
+    I2C_Write(_output.getLowData(output, false));
 
     //delayMicroseconds(37); // Some commands have different timing requirement,
                              // so every command should handle its own delay after execution

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -92,9 +92,9 @@ private:
     void LCD_Write(uint8_t output, bool initialization = false);
 
 private:
-    uint8_t _address;
-    uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
-    uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.
+    const uint8_t _address;
+    const uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
+    const uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.
     OutputState _output;
     uint8_t _displayState;
     uint8_t _entryState;

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -41,13 +41,13 @@ class TwoWire;
 class LCD_I2C : public Print
 {
 public:
-	/**
-	 * This constructor just uses the default TwoWire object 'Wire'.
-	 */
+    /**
+     * This constructor just uses the default TwoWire object 'Wire'.
+     */
     LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
 
-	/**
-	 * This constructor takes a TwoWire object so that the driver can
+    /**
+     * This constructor takes a TwoWire object so that the driver can
      * work on another interface.
      * In case that the hardware has a second TwoWire interface
      * which should be used for the LCD, just pass 'Wire1' as the
@@ -68,9 +68,9 @@ public:
      * Some microcontrollers (like ESP32) require to set sda pin and
      * scl pin for I2C.
      */
-	void begin(int sdaPin, int sclPin, bool beginWire = true);
+    void begin(int sdaPin, int sclPin, bool beginWire = true);
 
-	void begin(bool beginWire = true);
+    void begin(bool beginWire = true);
     void backlight();
     void noBacklight();
 
@@ -108,30 +108,30 @@ private:
     uint8_t _displayState;
     uint8_t _entryState;
 
-	/* This struct helps us constructing the I2C output based on data and control outputs.
-	   Because the LCD is set to 4-bit mode, 4 bits of the I2C output are for the control outputs
-	   while the other 4 bits are for the 8 bits of data which are send in parts using the enable output.*/
-	struct OutputState
-	{
-	    uint8_t rs = 0;
-	    uint8_t rw = 0;
-	    uint8_t Led = 0;
+    /* This struct helps us constructing the I2C output based on data and control outputs.
+       Because the LCD is set to 4-bit mode, 4 bits of the I2C output are for the control outputs
+       while the other 4 bits are for the 8 bits of data which are send in parts using the enable output.*/
+    struct OutputState
+    {
+        uint8_t rs = 0;
+        uint8_t rw = 0;
+        uint8_t Led = 0;
 
-	    uint8_t getLowData(uint8_t data, uint8_t E) const
-	    {
-	        return getCommonData(E) | ((data & 0x0F) << 4);
-	    }
+        uint8_t getLowData(uint8_t data, uint8_t E) const
+        {
+            return getCommonData(E) | ((data & 0x0F) << 4);
+        }
 
-	    uint8_t getHighData(uint8_t data, uint8_t E) const
-	    {
-	        return getCommonData(E) | (data & 0xF0);
-	    }
+        uint8_t getHighData(uint8_t data, uint8_t E) const
+        {
+            return getCommonData(E) | (data & 0xF0);
+        }
 
-	private:
-	    inline uint8_t getCommonData(uint8_t E) const {
-	    	return rs | (rw << 1) | (E << 2) | (Led << 3);
-	    }
-	} _output;
+    private:
+        inline uint8_t getCommonData(uint8_t E) const {
+            return rs | (rw << 1) | (E << 2) | (Led << 3);
+        }
+    } _output;
 };
 
 #endif // #ifndef _LCD_I2C_h

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -18,6 +18,8 @@
     along with this program.If not, see < https://www.gnu.org/licenses/>.
 */
 
+#pragma once
+
 #ifndef _LCD_I2C_h
 #define _LCD_I2C_h
 
@@ -121,4 +123,5 @@ private:
 	    }
 	} _output;
 };
-#endif
+
+#endif // #ifndef _LCD_I2C_h

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -34,7 +34,7 @@ struct OutputState
     uint8_t Led = 0;
     uint8_t data = 0;
 
-    uint8_t GetLowData()
+    uint8_t getLowData() const
     {
         uint8_t buffer = rs;
         buffer |= rw << 1;
@@ -45,7 +45,7 @@ struct OutputState
         return buffer;
     }
 
-    uint8_t GetHighData()
+    uint8_t getHighData() const
     {
         uint8_t buffer = rs;
         buffer |= rw << 1;

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -86,7 +86,7 @@ private:
     void InitializeLCD();
     void I2C_Write(uint8_t output);
     void LCD_WriteByte(uint8_t output);
-    inline void LCD_WriteNibble(uint8_t output);
+    inline void LCD_WriteHighNibble(uint8_t output);
 
 private:
     TwoWire& _wire;

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -23,11 +23,20 @@
 
 #include "Arduino.h"
 
+// Forward declaration of TwoWire avoids include of Wire.h here.
+class TwoWire;
+
 class LCD_I2C : public Print
 {
 public:
-    LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2)
-    : _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00) {}
+	// This constructor just uses the default TwoWire object 'Wire'.
+    LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
+
+	// This constructor takes a TwoWire object so that the driver can
+    // work on a different interface than 'Wire'. Just pass Wire1 or
+    // Wire2 etc. as the first parameter, in case that those objects
+    // are supported by the hardware.
+    LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
 
     // Some microcontrollers require to set sda and scl pin for I2C.
 	void begin(int sdaPin, int sclPin, bool beginWire = true);
@@ -61,6 +70,7 @@ private:
     void LCD_Write(uint8_t output, bool initialization = false);
 
 private:
+    TwoWire& _wire;
     const uint8_t _address;
     const uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
     const uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -29,6 +29,8 @@ public:
     LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2)
     : _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00) {}
 
+    // Some microcontrollers require to set sda and scl pin for I2C.
+	void begin(int sdaPin, int sclPin, bool beginWire = true);
     void begin(bool beginWire = true);
     void backlight();
     void noBacklight();
@@ -91,5 +93,4 @@ private:
 	    }
 	} _output;
 };
-
 #endif

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -60,7 +60,7 @@ class LCD_I2C : public Print
 {
 public:
     LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2)
-    : _address(address), _columnMax(--columns), _rowMax(--rows) {}
+    : _address(address), _columnMax(columns-1), _rowMax(rows-1), _displayState(0x00), _entryState(0x00) {}
 
     void begin(bool beginWire = true);
     void backlight();
@@ -93,11 +93,11 @@ private:
 
 private:
     uint8_t _address;
-    uint8_t _columnMax;
-    uint8_t _rowMax;
+    uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
+    uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.
     OutputState _output;
-    uint8_t _displayState = 0x00;
-    uint8_t _entryState = 0x00;
+    uint8_t _displayState;
+    uint8_t _entryState;
 };
 
 #endif

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -67,7 +67,8 @@ public:
 private:
     void InitializeLCD();
     void I2C_Write(uint8_t output);
-    void LCD_Write(uint8_t output, bool initialization = false);
+    void LCD_WriteByte(uint8_t output);
+    inline void LCD_WriteNibble(uint8_t output);
 
 private:
     TwoWire& _wire;
@@ -84,21 +85,20 @@ private:
 	{
 	    uint8_t rs = 0;
 	    uint8_t rw = 0;
-	    uint8_t E = 0;
 	    uint8_t Led = 0;
 
-	    uint8_t getLowData(uint8_t data) const
+	    uint8_t getLowData(uint8_t data, uint8_t E) const
 	    {
-	        return getCommonData() | ((data & 0x0F) << 4);
+	        return getCommonData(E) | ((data & 0x0F) << 4);
 	    }
 
-	    uint8_t getHighData(uint8_t data) const
+	    uint8_t getHighData(uint8_t data, uint8_t E) const
 	    {
-	        return getCommonData() | (data & 0xF0);
+	        return getCommonData(E) | (data & 0xF0);
 	    }
 
 	private:
-	    inline uint8_t getCommonData() const {
+	    inline uint8_t getCommonData(uint8_t E) const {
 	    	return rs | (rw << 1) | (E << 2) | (Led << 3);
 	    }
 	} _output;

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -36,23 +36,17 @@ struct OutputState
 
     uint8_t getLowData() const
     {
-        uint8_t buffer = rs;
-        buffer |= rw << 1;
-        buffer |= E << 2;
-        buffer |= Led << 3;
-        buffer |= (data & 0x0F) << 4;
-
-        return buffer;
+        return getCommonData() | ((data & 0x0F) << 4);
     }
 
     uint8_t getHighData() const
     {
-        uint8_t buffer = rs;
-        buffer |= rw << 1;
-        buffer |= E << 2;
-        buffer |= Led << 3;
-        buffer |= (data & 0xF0);
-        return buffer;
+        return getCommonData() | (data & 0xF0);
+    }
+
+private:
+    inline uint8_t getCommonData() const {
+    	return rs | (rw << 1) | (E << 2) | (Led << 3);
     }
 };
 

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -25,8 +25,18 @@
 
 #include "Arduino.h"
 
-/* Forward declaration of TwoWire avoids include of Wire.h here. */
+/**
+ * TwoWire class declaration is required for optionally using Wire1, Wire2.. objects
+ * for I2C interface.
+ * Forward declaration of TwoWire avoids include of Wire.h here and in user sketch.
+ */
+#ifdef ARDUINO_ARCH_MBED
+// Special handling for Mbed platforms required.
+namespace arduino {class MbedI2C;}
+typedef arduino::MbedI2C TwoWire;
+#else
 class TwoWire;
+#endif
 
 class LCD_I2C : public Print
 {

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -23,24 +23,42 @@
 
 #include "Arduino.h"
 
-// Forward declaration of TwoWire avoids include of Wire.h here.
+/* Forward declaration of TwoWire avoids include of Wire.h here. */
 class TwoWire;
 
 class LCD_I2C : public Print
 {
 public:
-	// This constructor just uses the default TwoWire object 'Wire'.
+	/**
+	 * This constructor just uses the default TwoWire object 'Wire'.
+	 */
     LCD_I2C(uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
 
-	// This constructor takes a TwoWire object so that the driver can
-    // work on a different interface than 'Wire'. Just pass Wire1 or
-    // Wire2 etc. as the first parameter, in case that those objects
-    // are supported by the hardware.
+	/**
+	 * This constructor takes a TwoWire object so that the driver can
+     * work on another interface.
+     * In case that the hardware has a second TwoWire interface
+     * which should be used for the LCD, just pass 'Wire1' as the
+     * first parameter. For the 3rd interface use 'Wire2', and so on.
+     *
+     * There is no need for the sketch to include the Wire.h header.
+     * Just declare the other TwoWire object to be used as 'extern'.
+     *
+     * Example:
+     *  #include <LCD_I2C.h>
+     *  extern TwoWire Wire1;
+     *  LCD_I2C(Wire1, 0x27, 16, 2);
+     *
+     */
     LCD_I2C(TwoWire& wire, uint8_t address, uint8_t columns = 16, uint8_t rows = 2);
 
-    // Some microcontrollers require to set sda and scl pin for I2C.
+    /**
+     * Some microcontrollers (like ESP32) require to set sda pin and
+     * scl pin for I2C.
+     */
 	void begin(int sdaPin, int sclPin, bool beginWire = true);
-    void begin(bool beginWire = true);
+
+	void begin(bool beginWire = true);
     void backlight();
     void noBacklight();
 

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -62,7 +62,7 @@ public:
     void setCursor(uint8_t col, uint8_t row);
 
     // Method used by the Arduino class "Print" which is the one that provides the .print(string) method
-    virtual size_t write(uint8_t character);
+    size_t write(uint8_t character) override;
 
 private:
     void InitializeLCD();

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -23,32 +23,6 @@
 
 #include "Arduino.h"
 
-/* This struct helps us constructing the I2C output based on data and control outputs.
-   Because the LCD is set to 4-bit mode, 4 bits of the I2C output are for the control outputs
-   while the other 4 bits are for the 8 bits of data which are send in parts using the enable output.*/
-struct OutputState
-{
-    uint8_t rs = 0;
-    uint8_t rw = 0;
-    uint8_t E = 0;
-    uint8_t Led = 0;
-
-    uint8_t getLowData(uint8_t data) const
-    {
-        return getCommonData() | ((data & 0x0F) << 4);
-    }
-
-    uint8_t getHighData(uint8_t data) const
-    {
-        return getCommonData() | (data & 0xF0);
-    }
-
-private:
-    inline uint8_t getCommonData() const {
-    	return rs | (rw << 1) | (E << 2) | (Led << 3);
-    }
-};
-
 class LCD_I2C : public Print
 {
 public:
@@ -88,9 +62,34 @@ private:
     const uint8_t _address;
     const uint8_t _columnMax; // Last valid column index. Note the column index starts at zero.
     const uint8_t _rowMax;    // Last valid row index. Note the row index starts at zero.
-    OutputState _output;
     uint8_t _displayState;
     uint8_t _entryState;
+
+	/* This struct helps us constructing the I2C output based on data and control outputs.
+	   Because the LCD is set to 4-bit mode, 4 bits of the I2C output are for the control outputs
+	   while the other 4 bits are for the 8 bits of data which are send in parts using the enable output.*/
+	struct OutputState
+	{
+	    uint8_t rs = 0;
+	    uint8_t rw = 0;
+	    uint8_t E = 0;
+	    uint8_t Led = 0;
+
+	    uint8_t getLowData(uint8_t data) const
+	    {
+	        return getCommonData() | ((data & 0x0F) << 4);
+	    }
+
+	    uint8_t getHighData(uint8_t data) const
+	    {
+	        return getCommonData() | (data & 0xF0);
+	    }
+
+	private:
+	    inline uint8_t getCommonData() const {
+	    	return rs | (rw << 1) | (E << 2) | (Led << 3);
+	    }
+	} _output;
 };
 
 #endif

--- a/src/LCD_I2C.h
+++ b/src/LCD_I2C.h
@@ -32,14 +32,13 @@ struct OutputState
     uint8_t rw = 0;
     uint8_t E = 0;
     uint8_t Led = 0;
-    uint8_t data = 0;
 
-    uint8_t getLowData() const
+    uint8_t getLowData(uint8_t data) const
     {
         return getCommonData() | ((data & 0x0F) << 4);
     }
 
-    uint8_t getHighData() const
+    uint8_t getHighData(uint8_t data) const
     {
         return getCommonData() | (data & 0xF0);
     }


### PR DESCRIPTION
Because I need this driver on an Arduino Due and an ESP32 microcontroller using the 2nd I2C interface, I did the following enhancements:

1) I added support for using a different I2C interface than the default one. Now it is possible run the LCD_I2C driver also on 'Wire1', 'Wire2' etc. depending on the number of I2C interfaces that the hardware supports.  E.g. Arduino Due has two I2C interfaces controlled by 2 C++ objects 'Wire' and 'Wire1'.
2) I added support for ESP32. In particular this is mapping the I2C sda and scl signals to the gpio pins. Hence the user sketch does't need to deal with the Wire.h header file when using the LCD_I2C driver on ESP32 microcontrollers.
3) Finally I did a little bit of refactoring in a way that I think it would streamline the code.